### PR TITLE
psutil function is out of date.

### DIFF
--- a/device-types/raspberry-pi/raspberrypi.py
+++ b/device-types/raspberry-pi/raspberrypi.py
@@ -36,7 +36,7 @@ def reboot(t=1):
 def getData():
     temp =  round(int(open('/sys/class/thermal/thermal_zone0/temp').read()) / 1e3,1)
     perc = psutil.cpu_percent()
-    memAvail = round(psutil.avail_phymem()/1000000,1)
+    memAvail = round(psutil.virtual_memory().used/1000000,1)
     diskUsage =  psutil.disk_usage('/').percent
     j = {'cpu_temp': temp, 'cpu_perc': perc, 'mem_avail': memAvail, 'disk_usage': diskUsage}
     return json.dumps(j,indent=4, separators=(',', ': '))


### PR DESCRIPTION
psutil.avail_phymem() is no longer callable from version v3.0 of psutil and elicits an error from webiopi which causes the tiles to be "grayed out". The issue has been reported in SmartThings forum thread https://community.smartthings.com/t/raspberry-pi-device-type/4969.  This is fixed by replacing psutil.avail_phymem() with the new function psutil.virtual_memory().used.
